### PR TITLE
Allow different dispatch strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Advanced configuration format
 - Allow configuring basic auth for targets
+- Configuration for dispatch strategies, with possible custom implementations
 
 ## 1.0.0 - 2018-10-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a service to integrate third party integrations with multiple environmen
 
 It can distribute callbacks to several systems, for example:
 
-    proxy.example.com/paypal/dev/postBack
+    proxy.example.com/paypal-dev/postBack
     
     =>
     
@@ -40,7 +40,7 @@ If it is used for dev systems, only the proxy must be made accessible from outsi
     ```
     'proxy' => [
         'targets' => [
-            'paypal/dev' => [
+            'paypal-dev' => [
                 'https://dev1.example.com/paypal/',
                 'https://dev2.example.com/paypal/',
             ],
@@ -48,7 +48,7 @@ If it is used for dev systems, only the proxy must be made accessible from outsi
     ],
     ```
     
-    This example routes `/paypal/dev/*` to `https://dev1.example.com/paypal/*` and `https://dev2.example.com/paypal/*`.
+    This example routes `/paypal-dev/*` to `https://dev1.example.com/paypal/*` and `https://dev2.example.com/paypal/*`.
     
 ## Advanced Configuration
 
@@ -74,6 +74,12 @@ composer test
 ```
 
 Runs unit tests, mutation tests and static analysis
+
+```
+php -S localhost:9000 -t public 
+```
+
+Starts the proxy locally on port 9000 for manual testing. Needs a valid configuration in `config.php`. As a generic target URI, you can use `https://httpbin.org/anything/`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If it is used for dev systems, only the proxy must be made accessible from outsi
     ```
     
     This example routes `/paypal-dev/*` to `https://dev1.example.com/paypal/*` and `https://dev2.example.com/paypal/*`.
-    
+
 ## Advanced Configuration
 
 Instead of a plain URI string, each target can also be configured with additional options:
@@ -63,6 +63,24 @@ Instead of a plain URI string, each target can also be configured with additiona
 
 - **uri** (required) - the base URI
 - **basic-auth** - HTTP basic authentication in the form "username:password"
+
+The default dispatcher strategy is to dispatch the request to all targets and return the first successful (2xx) response.
+
+You can choose a different strategy in `config.php`:
+
+```
+'proxy' => [
+    'strategy' => \IntegerNet\CallbackProxy\DispatchStrategy\DispatchAllReturnFirstSuccess::class,
+]
+```
+
+**Available Strategies:**
+
+- `\IntegerNet\CallbackProxy\DispatchStrategy\DispatchAllReturnFirstSuccess::class` - the default strategy, see above
+- `\IntegerNet\CallbackProxy\DispatchStrategy\StopOnFirstSucces::class` - returns the first successful (2xx) response, stops dispatching further targets 
+
+You can implement your own strategies, by implementing the `\IntegerNet\CallbackProxy\DispatchStrategy` interface. 
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/config.php.sample
+++ b/config.php.sample
@@ -5,6 +5,7 @@
 return [
     'displayErrorDetails' => true,
     'proxy' => [
+        'strategy' => \IntegerNet\CallbackProxy\DispatchStrategy\DispatchAllReturnFirstSuccess::class,
         'targets' => [
             'paypal-dev' => [
                 'https://dev1.example.com/paypal/',

--- a/config.php.sample
+++ b/config.php.sample
@@ -6,12 +6,12 @@ return [
     'displayErrorDetails' => true,
     'proxy' => [
         'targets' => [
-            'paypal/dev' => [
+            'paypal-dev' => [
                 'https://dev1.example.com/paypal/',
                 'https://dev2.example.com/paypal/',
                 'https://dev3.example.com/paypal/',
             ],
-            'paypal/qa' => [
+            'paypal-qa' => [
                 'https://qa1.example.com/paypal/',
                 'https://qa2.example.com/paypal/',
                 'https://qa3.example.com/paypal/',

--- a/public/index.php
+++ b/public/index.php
@@ -3,6 +3,8 @@
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\StreamHandler;
 use IntegerNet\CallbackProxy\Dispatcher;
+use IntegerNet\CallbackProxy\DispatchStrategy;
+use IntegerNet\CallbackProxy\HttpClient;
 use IntegerNet\CallbackProxy\Targets;
 use Psr\Http\Message\RequestInterface;
 use Slim\Container;
@@ -11,13 +13,15 @@ use Slim\Http\Response;
 require __DIR__ . '/../vendor/autoload.php';
 
 $config = [
-    'settings' => include '../config.php',
-    'httpClient' => function (Container $container) {
-        return new Client(
-            [
-                'handler' => new StreamHandler(),
-                'verify' => false,
-            ]
+    'settings'     => include '../config.php',
+    'httpClient'   => function (Container $container) : HttpClient {
+        return new HttpClient(
+            new Client(
+                [
+                    'handler' => new StreamHandler(),
+                    'verify'  => false,
+                ]
+            )
         );
     },
     'proxyTargets' => function (Container $container) {
@@ -28,20 +32,28 @@ $config = [
             $container->settings['proxy']['targets']
         );
     },
+    'dispatchStrategy' => function (Container $container) : DispatchStrategy {
+        $class = $container->settings['proxy']['strategy'] ?? DispatchStrategy\DispatchAllReturnFirstSuccess::class;
+        return new $class;
+    },
 ];
 $app = new \Slim\App($config);
 
-$app->any('/{target}/{action}', function (RequestInterface $request, Response $response, array $args) {
-    /** @var $this Container */
-    $targets = $this->get('proxyTargets');
-    if (!isset($targets[$args['target']])) {
-        return $response->withStatus(500)->write("Target {$args['target']} does not exist.");
+$app->any(
+    '/{target}/{action}',
+    function (RequestInterface $request, Response $response, array $args) {
+        /** @var $this Container */
+        $targets = $this->get('proxyTargets');
+        if (!isset($targets[$args['target']])) {
+            return $response->withStatus(500)->write("Target {$args['target']} does not exist.");
+        }
+        $dispatcher = new Dispatcher(
+            $this->get('httpClient'),
+            $targets[$args['target']],
+            $this->get('dispatchStrategy')
+        );
+        return $dispatcher->dispatch($request, $response, $args['action']);
     }
-    $dispatcher = new Dispatcher(
-        $this->get('httpClient'),
-        ...$targets[$args['target']]
-    );
-    return $dispatcher->dispatch($request, $response, $args['action']);
-});
+);
 
 $app->run();

--- a/src/DispatchStrategy.php
+++ b/src/DispatchStrategy.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace IntegerNet\CallbackProxy;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface DispatchStrategy
+{
+    public function execute(
+        HttpClient $client,
+        Targets $targets,
+        RequestInterface $request,
+        ResponseInterface $response,
+        string $action
+    ): ResponseInterface;
+}

--- a/src/DispatchStrategy/DispatchAllReturnFirstSuccess.php
+++ b/src/DispatchStrategy/DispatchAllReturnFirstSuccess.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace IntegerNet\CallbackProxy\DispatchStrategy;
+
+use IntegerNet\CallbackProxy\DispatchStrategy;
+use IntegerNet\CallbackProxy\HttpClient;
+use IntegerNet\CallbackProxy\Targets;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class DispatchAllReturnFirstSuccess implements DispatchStrategy
+{
+    public function execute(
+        HttpClient $client,
+        Targets $targets,
+        RequestInterface $request,
+        ResponseInterface $response,
+        string $action
+    ): ResponseInterface {
+        $firstSuccessfulResponse = null;
+        foreach ($targets as $target) {
+            $response = $client->send($request, $target, $action);
+            if ($firstSuccessfulResponse === null && $this->responseIsSuccessful($response)) {
+                $firstSuccessfulResponse = $response;
+            }
+        }
+        return $firstSuccessfulResponse ?? $response;
+    }
+
+    private function responseIsSuccessful(ResponseInterface $response): bool
+    {
+        return $response->getStatusCode() >= 200 && $response->getStatusCode() < 300;
+    }
+}

--- a/src/DispatchStrategy/StopOnFirstSuccess.php
+++ b/src/DispatchStrategy/StopOnFirstSuccess.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace IntegerNet\CallbackProxy\DispatchStrategy;
+
+use IntegerNet\CallbackProxy\DispatchStrategy;
+use IntegerNet\CallbackProxy\HttpClient;
+use IntegerNet\CallbackProxy\Targets;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class StopOnFirstSuccess implements DispatchStrategy
+{
+    public function execute(
+        HttpClient $client,
+        Targets $targets,
+        RequestInterface $request,
+        ResponseInterface $response,
+        string $action
+    ): ResponseInterface {
+        foreach ($targets as $target) {
+            $response = $client->send($request, $target, $action);
+            if ($this->responseIsSuccessful($response)) {
+                return $response;
+            }
+        }
+        return $response;
+    }
+
+    private function responseIsSuccessful(ResponseInterface $response): bool
+    {
+        return $response->getStatusCode() >= 200 && $response->getStatusCode() < 300;
+    }
+}

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -2,11 +2,8 @@
 
 namespace IntegerNet\CallbackProxy;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\UriInterface;
 
 /**
  * Dispatches a request to multiple targets, returns first successful response (HTTP 200) or last response if none are
@@ -15,47 +12,27 @@ use Psr\Http\Message\UriInterface;
 class Dispatcher
 {
     /**
-     * @var Client
+     * @var HttpClient
      */
     private $client;
     /**
-     * @var Target[]
+     * @var Targets
      */
     private $targets;
+    /**
+     * @var DispatchStrategy
+     */
+    private $strategy;
 
-    public function __construct(Client $client, Target ...$targets)
+    public function __construct(HttpClient $client, Targets $targets, DispatchStrategy $strategy)
     {
         $this->client = $client;
         $this->targets = $targets;
+        $this->strategy = $strategy;
     }
 
     public function dispatch(RequestInterface $request, ResponseInterface $response, string $action): ResponseInterface
     {
-        $firstSuccessfulResponse = null;
-        foreach ($this->targets as $target) {
-            $response = $this->dispatchSingle($request, $target, $action);
-            if ($firstSuccessfulResponse === null && $this->responseIsSuccessful($response)) {
-                $firstSuccessfulResponse = $response;
-            }
-        }
-        return $firstSuccessfulResponse ?? $response;
-    }
-
-    private function dispatchSingle(RequestInterface $request, Target $target, string $action): ResponseInterface
-    {
-        try {
-            $response = $this->client->send($target->applyToRequest($request, $action));
-            return $target->applyToResponse($response, $action);
-        } catch (RequestException $e) {
-            if ($e->getResponse() instanceof ResponseInterface) {
-                return $target->applyToResponse($e->getResponse(), $action);
-            }
-            throw $e;
-        }
-    }
-
-    private function responseIsSuccessful(ResponseInterface $response): bool
-    {
-        return $response->getStatusCode() >= 200 && $response->getStatusCode() < 300;
+        return $this->strategy->execute($this->client, $this->targets, $request, $response, $action);
     }
 }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace IntegerNet\CallbackProxy;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Client to forward requests to configured Target
+ */
+class HttpClient
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function send(RequestInterface $request, Target $target, string $action): ResponseInterface
+    {
+        try {
+            $response = $this->client->send($target->applyToRequest($request, $action));
+            return $target->applyToResponse($response, $action);
+        } catch (RequestException $e) {
+            if ($e->getResponse() instanceof ResponseInterface) {
+                return $target->applyToResponse($e->getResponse(), $action);
+            }
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
The default is to dispatch the request to all targets and return the first successful response.

An alternative has been added, to stop dispatching after the first successful response.

Custom strategies may be implemented.