### PR TITLE
Remove Transfer-Encoding header from response

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -52,7 +52,9 @@ $app->any(
             $targets[$args['target']],
             $this->get('dispatchStrategy')
         );
-        return $dispatcher->dispatch($request, $response, $args['action']);
+        $response = $dispatcher->dispatch($request, $response, $args['action']);
+
+        return $response->withoutHeader('Transfer-Encoding');
     }
 );
 


### PR DESCRIPTION
If the target returns "Transfer-Encoding: chunked", it results in an empty response otherwise